### PR TITLE
[SMALL FEATURE] Add flush on task log print.

### DIFF
--- a/audithub_client/api/monitor_task.py
+++ b/audithub_client/api/monitor_task.py
@@ -102,7 +102,7 @@ def api_monitor_task(context: AuditHubContext, input: MonitorTaskArgs) -> bool:
                         ),
                     )
                 elif kind == "TaskStepLogMessage":
-                    print(f"[{task_message["step_code"]}] {task_message["entry"]}")
+                    print(f"[{task_message["step_code"]}] {task_message["entry"]}", flush=True)
         except ConnectionClosedOK as ex:
             logger.info("Websocket client: All server logs are received.", ex.reason)
         except Exception as ex:  # pylint: disable=broad-exception-caught


### PR DESCRIPTION
I noticed that when interacting with AuditHub sometimes it seemed to buffer the output printed to stdout, which makes it hard to use the output to determine progress. This is fixed by flushing the print to stdout.