### PR TITLE
Support for Vanguard-V2 custom detectors.

### DIFF
--- a/audithub_client/api/start_vanguard_task.py
+++ b/audithub_client/api/start_vanguard_task.py
@@ -13,18 +13,58 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
+class CustomDetectorFromVersion:
+    relative_path: str
+    type: Literal["version"] = "version"
+
+
+@dataclass
+class CustomDetectorFromStandardLibrary:
+    category: str
+    name: str
+    library_version: Optional[str] = None
+    type: Literal["stdlib"] = "stdlib"
+
+
+@dataclass
+class CustomDetectorFromOrganizationLibrary:
+    id: int
+    type: Literal["orglib"] = "orglib"
+
+
+CustomDetectorsForTask = list[
+    CustomDetectorFromVersion
+    | CustomDetectorFromStandardLibrary
+    | CustomDetectorFromOrganizationLibrary
+]
+
+
+class NoDetectorsDefinedError(ValueError):
+    def __init__(self):
+        super().__init__("No detectors defined, standard or custom!")
+
+
+@dataclass
 class StartVanguardTaskArgs:
     organization_id: int
     project_id: int
     version_id: int
     name: Optional[str]
     detector: list[str]
+    custom_detectors: Optional[CustomDetectorsForTask]
+
     input_limit: Optional[list[str]]
     tool_name: Literal["vanguard", "vanguard-v2", "zk-vanguard"]
 
 
 def api_start_vanguard_task(context: AuditHubContext, input: StartVanguardTaskArgs):
     logger.debug("Starting Vanguard")
+    count_custom_detectors = (
+        0 if input.custom_detectors is None else len(input.custom_detectors)
+    )
+    count_detectors = len(input.detector)
+    if count_custom_detectors + count_detectors == 0:
+        raise NoDetectorsDefinedError()
 
     data = {
         "name": input.name,

--- a/audithub_client/library/invocation_common.py
+++ b/audithub_client/library/invocation_common.py
@@ -49,7 +49,8 @@ TaskIdType = Annotated[
 TaskWaitType = Annotated[
     bool,
     Parameter(
-        help="If specified, this script will monitor the task and wait for it to finish. The exit code will reflect the success or failure of the task, regardless of findings produced by the analysis."
+        negative_bool=(),
+        help="If specified, this script will monitor the task and wait for it to finish. The exit code will reflect the success or failure of the task, regardless of findings produced by the analysis.",
     ),
 ]
 

--- a/audithub_client/scripts/start_orca_task.py
+++ b/audithub_client/scripts/start_orca_task.py
@@ -21,6 +21,7 @@ from ..library.invocation_common import (
     AuditHubContextType,
     OrganizationIdType,
     ProjectIdType,
+    TaskWaitType,
     VersionIdType,
     app,
 )
@@ -60,7 +61,7 @@ def start_orca_task(
         Optional[list[str]], Parameter(consume_multiple=True, negative_iterable=())
     ] = None,
     deployment_script_path: Optional[str] = None,
-    wait: bool = False,
+    wait: TaskWaitType = False,
     rpc_context: AuditHubContextType,
 ):
     """
@@ -112,8 +113,6 @@ def start_orca_task(
     deployment_script_path:
         An optional deployment script path to be used during deployment. If provided, it overrides the value set in project level.
 
-    wait:
-        If specified, this script will monitor the task and wait for it to finish. The exit code will reflect the success or failure of the task, regardless of findings produced by the analysis.
     """
 
     specs: list[VSpec] = []

--- a/audithub_client/scripts/start_picus_v2_task.py
+++ b/audithub_client/scripts/start_picus_v2_task.py
@@ -8,6 +8,7 @@ from ..library.invocation_common import (
     AuditHubContextType,
     OrganizationIdType,
     ProjectIdType,
+    TaskWaitType,
     VersionIdType,
     app,
 )
@@ -27,7 +28,7 @@ def start_picus_v2_task(
     solver_timeout: Optional[int] = None,
     time_limit: Optional[int] = None,
     assume_deterministic: Optional[list[str]] = None,
-    wait: bool = False,
+    wait: TaskWaitType = False,
     rpc_context: AuditHubContextType,
 ):
     """
@@ -60,8 +61,6 @@ def start_picus_v2_task(
         An optional list of modules inside the selected source file.
         Tells Picus to assume the list of modules provided are deterministic.
 
-    wait:
-        If specified, this script will monitor the task and wait for it to finish. The exit code will reflect the success or failure of the task, regardless of findings produced by the analysis.
     """
     try:
         rpc_input = StartPicusV2TaskArgs(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "audithub-client"
-version = "1.1.5"
+version = "1.1.6"
 description = "A Python client that can access Veridise AuditHub via its REST API, providing CLI access"
 authors = ["Nikos Chondros <nikos@veridise.com>"]
 license = "AGPLv3"


### PR DESCRIPTION
We support custom detectors from all three possible sources: embedded in the version archive, from the Veridise-maintained standard library, and from the user-maintained organization-level library.