### PR TITLE
Change default of Picus global timeout, some clarifications on help text.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,8 @@ tag:
 .PHONY: push-tag
 push-tag:
 	git push --tags
+
+
+.PHONY: pre-commit-hooks
+pre-commit-hooks:
+	poetry run pre-commit run --all-files

--- a/audithub_client/scripts/start_picus_v2_task.py
+++ b/audithub_client/scripts/start_picus_v2_task.py
@@ -29,7 +29,7 @@ def start_picus_v2_task(
         Literal["cvc5", "cvc5-ff-int", "z3", "multi-solver", "z3bv", "bitwuzla"]
     ] = None,
     solver_timeout: Optional[int] = None,
-    time_limit: Optional[int] = None,
+    time_limit: int = 1800000,
     assume_deterministic: Optional[list[str]] = None,
     enable_debug: Optional[BooleanArg] = None,
     wait: TaskWaitType = False,
@@ -56,11 +56,11 @@ def start_picus_v2_task(
         z3bv is the z3 bitvector solver.
 
     solver_timeout:
-        Timeout set for each solver query, in milliseconds (default: 5000 ms).
+        Timeout set for each solver query, in milliseconds (If not provided, default is 5 seconds).
 
     time_limit:
         Global timeout. If Picus takes longer than the time_limit provided then it will terminate.
-        Value in milliseconds (default: unlimited).
+        Value in milliseconds (if set to 0, it means unlimited).
 
     assume_deterministic:
         An optional list of modules inside the selected source file.
@@ -79,7 +79,7 @@ def start_picus_v2_task(
             source=source,
             solver=solver,
             solver_timeout=solver_timeout,
-            time_limit=time_limit,
+            time_limit=None if time_limit == 0 else time_limit,
             assume_deterministic=assume_deterministic,
             enable_debug=enable_debug,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "audithub-client"
-version = "1.1.17"
+version = "1.1.18"
 description = "A Python client that can access Veridise AuditHub via its REST API, providing CLI access"
 authors = ["Nikos Chondros <nikos@veridise.com>"]
 license = "AGPLv3"


### PR DESCRIPTION
Change Picus global timeout default value from `null` (meaning unlimited) to 30 minutes, as we did at the frontend. if users really wants unlimited, they will have to set a global timeout of 0.

Also changed the help text of `solver-timeout` to denote that if no value is set, it means a default of 5 secs.